### PR TITLE
Use cortex_m_semihosting crate to remove unsafe asm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "pin_verif"
 version = "0.1.0"
 edition = "2018"
 
+[dependencies]
+cortex-m-semihosting = "0.3.7"
+
 [dev-dependencies]
 testmacro = { git = "https://github.com/yhql/testmacro"}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,8 +152,6 @@ mod tests {
 #[cfg(test)]
 #[no_mangle]
 pub fn _start() -> ! {
-    #[cfg(test)]
     test_main();
-
-    qemu::exit();
+    loop {}
 }

--- a/src/qemu.rs
+++ b/src/qemu.rs
@@ -1,54 +1,12 @@
-use core::arch::asm;
-
-#[cfg(test)]
-pub fn exit() -> ! {
-    unsafe {
-        asm!(
-            "bkpt #0xab",
-            in("r1") 0x20026, // ADP_Stopped_ApplicationExit
-            inout("r0") 0x18 => _,
-        );
-    }
-
-    loop {}
-}
-
-// Print using semihosting
-// Used to easily display something in QEMU
-pub fn debug_print(s: &str) {
-    let p = s.as_bytes().as_ptr();
-    for i in 0..s.len() {
-        let m = unsafe { p.offset(i as isize) };
-        unsafe {
-            asm!(
-                "bkpt #0xab",
-                in("r1") m,
-                inout("r0") 3 => _,
-            );
-        }
-    }
-}
-
-struct DebugStruct {}
-
-impl DebugStruct {
-    pub fn new() -> DebugStruct {
-        DebugStruct {}
-    }
-}
-
 use core::fmt;
-
-impl fmt::Write for DebugStruct {
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        crate::qemu::debug_print(s);
-        Ok(())
-    }
-}
 
 pub fn _print(args: fmt::Arguments) {
     use core::fmt::Write;
-    DebugStruct::new().write_fmt(args).unwrap();
+    use cortex_m_semihosting::hio;
+
+    if let Ok(mut hstdout) = hio::hstdout() {
+        write!(hstdout, "{}", args).ok();
+    }
 }
 
 #[macro_export]

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -20,12 +20,19 @@ pub struct TestType {
 
 use crate::{print, println};
 pub fn test_runner(tests: &[&TestType]) {
+    use cortex_m_semihosting::debug::{self, EXIT_SUCCESS, EXIT_FAILURE};
+
     println!("--- {} tests ---", tests.len());
+    let mut return_code = EXIT_SUCCESS;
     for t in tests {
         match (t.f)() {
             Ok(()) => print!("\x1b[1;32m   ok   \x1b[0m"),
-            Err(()) => print!("\x1b[1;31m  fail  \x1b[0m"),
+            Err(()) => {
+                print!("\x1b[1;31m  fail  \x1b[0m");
+                return_code = EXIT_FAILURE;
+            }
         }
         println!("{}::{}", t.modname, t.name);
     }
+    debug::exit(return_code);
 }


### PR DESCRIPTION
https://doc.rust-lang.org/nomicon/panic-handler.html proposes two crates to handle panics in a `no_std` environment, one of which is using `cortex_m_semihosting` crate to print and exit.

Let's use `cortex_m_semihosting` crate in our code to remove the need to do unsafe assembly.