### PR TITLE
What happens if I remove the inline?

### DIFF
--- a/fault_hardened/src/lib.rs
+++ b/fault_hardened/src/lib.rs
@@ -27,7 +27,6 @@ impl<T: PartialEq> PartialEq<&T> for Protected<T> {
     /// succeeded
     /// Always inline because otherwise the call to `eq()` could
     /// be skipped.
-    #[inline(always)]
     fn eq(&self, rhs: &&T) -> bool {
         if compare_never_inlined(rhs, &&self.0) {
             if compare_never_inlined(&self.0, rhs) {


### PR DESCRIPTION
This pull request shows the effect of an evil commit introducing vulnerabilities. The fault injection evaluation check fails with:
![image](https://user-images.githubusercontent.com/101575901/181712337-5dae3d88-701c-43b8-96f0-0042ae936469.png)
